### PR TITLE
Changed InterfaceOptionsFrame call

### DIFF
--- a/Altoholic_Summary/TabSummary.xml
+++ b/Altoholic_Summary/TabSummary.xml
@@ -120,8 +120,8 @@
 				</KeyValues>
 				<Scripts>
 					<OnClick>
-						Altoholic:ToggleUI()
-						InterfaceOptionsFrame_OpenToCategory("DataStore")
+						Altoholic.Tabs:OnClick("Options")
+						AltoholicTabOptions.MenuItem7:Click()
 					</OnClick>
 				</Scripts>
 			</Button>
@@ -134,8 +134,8 @@
 				</KeyValues>
 				<Scripts>
 					<OnClick>
-						Altoholic:ToggleUI()
-						InterfaceOptionsFrame_OpenToCategory("Altoholic")
+						Altoholic.Tabs:OnClick("Options")
+						AltoholicTabOptions.MenuItem1:Click()
 					</OnClick>
 				</Scripts>
 			</Button>


### PR DESCRIPTION
Removed the call to InterfaceOptionsFrame_OpenToCategory (it no longer exists). Changed the call to use the internal Altoholic settings.
It is using <MenuItemX> frames, so it's not the optimal solution, but it does solve the LUA errors.